### PR TITLE
Fix error allowing invalid fontWeight values

### DIFF
--- a/.changeset/plenty-icons-enjoy.md
+++ b/.changeset/plenty-icons-enjoy.md
@@ -1,0 +1,9 @@
+---
+'@emotion/serialize': major
+---
+
+What: Fix error allowing invalid fontWeight values
+
+Why: The `fontweight` property of CSSObject allows invalid values (e.g. 'wrong'). It's expected behavior is to show an error.
+
+How: Add `validFontWeight` type to `StrictCSSProperties`, declaring which values are only allowed.

--- a/packages/serialize/src/index.ts
+++ b/packages/serialize/src/index.ts
@@ -13,7 +13,29 @@ type Cursor = {
   next?: Cursor
 }
 
-export type CSSProperties = CSS.PropertiesFallback<number | string>
+type ValidFontWeight =
+  | 'normal'
+  | 'bold'
+  | 'lighter'
+  | 'bolder'
+  | 100
+  | 200
+  | 300
+  | 400
+  | 500
+  | 600
+  | 700
+  | 800
+  | 900
+
+type StrictCSSProperties = Omit<
+  CSS.PropertiesFallback<number | string>,
+  'fontWeight'
+> & {
+  fontWeight?: ValidFontWeight
+}
+
+export type CSSProperties = StrictCSSProperties
 export type CSSPropertiesWithMultiValues = {
   [K in keyof CSSProperties]:
     | CSSProperties[K]
@@ -91,6 +113,13 @@ const processStyleName = /* #__PURE__ */ memoize((styleName: string) =>
     : styleName.replace(hyphenateRegex, '-$&').toLowerCase()
 )
 
+const isValidFontWeight = (value: any): value is ValidFontWeight => {
+  if (typeof value === 'number') {
+    return value >= 100 && value <= 900 && value % 100 === 0
+  }
+  return ['normal', 'bold', 'lighter', 'bolder'].includes(value)
+}
+
 let processStyleValue = (
   key: string,
   value: string | number
@@ -145,6 +174,14 @@ if (isDevelopment) {
       ) {
         throw new Error(
           `You seem to be using a value for 'content' without quotes, try replacing it with \`content: '"${value}"'\``
+        )
+      }
+    }
+
+    if (key === 'fontWeight') {
+      if (!isValidFontWeight(value)) {
+        throw new Error(
+          `Invalid font-weight value: ${value}. Valid values are: normal, bold, lighter, bolder, or numbers 100-900 in increments of 100.`
         )
       }
     }


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Fixes error allowing invalid fontWeight values

<!-- Why are these changes necessary? -->

**Why**: The `fontweight` property of CSSObject allows invalid values (e.g. 'wrong'). It's expected behavior is to show an error.

<!-- How were these changes implemented? -->

**How**: Add `validFontWeight` type to `StrictCSSProperties`, declaring which values are only allowed.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
