### PR TITLE
Add autocomplete suggestion for styled.

### DIFF
--- a/.changeset/friendly-jeans-shave.md
+++ b/.changeset/friendly-jeans-shave.md
@@ -1,0 +1,9 @@
+---
+'@emotion/styled': major
+---
+
+What: Add autocomplete suggestion for styled. Fixes #3312
+
+Why: When typing "styled" while coding, there are no autocompletion suggestions for styled. It's expected behavior is to have a suggestion option and when selected, imports styled like this: import styled from @emotion/styled
+
+How: The previous code imports the base styled as styled. This changes it to baseStyled so the module can use styled as the default export.

--- a/packages/styled/src/index.ts
+++ b/packages/styled/src/index.ts
@@ -1,5 +1,5 @@
 import { Theme } from '@emotion/react'
-import styled from './base'
+import baseStyled from './base'
 import { ReactJSXIntrinsicElements } from './jsx-namespace'
 import { tags } from './tags'
 import {
@@ -33,10 +33,10 @@ export type StyledTags = {
 export interface CreateStyled extends BaseCreateStyled, StyledTags {}
 
 // bind it to avoid mutating the original function
-const newStyled = styled.bind(null) as CreateStyled
+const styled = baseStyled.bind(null) as CreateStyled
 
 tags.forEach(tagName => {
-  ;(newStyled as any)[tagName] = newStyled(tagName as keyof typeof newStyled)
+  ;(styled as any)[tagName] = styled(tagName as keyof typeof styled)
 })
 
-export default newStyled
+export default styled


### PR DESCRIPTION
<!--
Thanks for your interest in the project. I appreciate bugs filed and PRs submitted!

Please make sure that you are familiar with and follow the Code of Conduct for
this project (found in the CODE_OF_CONDUCT.md file).

Also, please make sure you're familiar with and follow the instructions in the
contributing guidelines (found in the CONTRIBUTING.md file).

If you're new to contributing to open source projects, you might find this free
video course helpful: http://kcd.im/pull-request

Please fill out the information below to expedite the review and (hopefully)
merge of your pull request!
-->

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**: Add autocomplete suggestion for styled.

<!-- Why are these changes necessary? -->

**Why**: When typing "styled" while coding, there are no autocompletion suggestions for styled. It's expected behavior is to have a suggestion option and when selected, imports styled like this: import styled from `@emotion/styled`

<!-- How were these changes implemented? -->

**How**: The previous code imports the base styled as `styled`. This changes it to `baseStyled` so the module can use `styled` as the default export.

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [x] Tests
- [x] Code complete
- [x] Changeset <!-- This is necessary if your changes should release any packages. Run `yarn changeset` to create a changeset -->

<!-- feel free to add additional comments -->
